### PR TITLE
Add broadcast demo example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/chat",
     "examples/flood",
     "examples/log",
+    "examples/broadcast-demo",
     "examples/vrf",
 ]
 resolver = "2"

--- a/examples/broadcast-demo/Cargo.toml
+++ b/examples/broadcast-demo/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "commonware-broadcast-demo"
+edition = "2021"
+publish = true
+version = "0.0.50"
+license = "MIT OR Apache-2.0"
+description = "Demonstrate the commonware-broadcast primitive."
+readme = "README.md"
+homepage = "https://commonware.xyz"
+repository = "https://github.com/commonwarexyz/monorepo/tree/main/examples/broadcast-demo"
+documentation = "https://docs.rs/commonware-broadcast-demo"
+
+[dependencies]
+commonware-broadcast = { workspace = true }
+commonware-codec = { workspace = true }
+commonware-cryptography = { workspace = true }
+commonware-macros = { workspace = true }
+commonware-p2p = { workspace = true }
+commonware-runtime = { workspace = true }
+commonware-utils = { workspace = true }
+bytes = { workspace = true }
+rand = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
+clap = { workspace = true }
+prometheus-client = { workspace = true }
+governor = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
+
+[[bin]]
+name = "commonware-broadcast-demo"
+bench = false

--- a/examples/broadcast-demo/README.md
+++ b/examples/broadcast-demo/README.md
@@ -1,0 +1,33 @@
+# commonware-broadcast-demo
+
+Simple demonstration of the `commonware-broadcast` primitive.
+
+## Usage (4 Participants)
+
+_To run this example, you must first install [Rust](https://www.rust-lang.org/tools/install)._
+
+Run at least four participants. Exactly one should broadcast a message using the `--broadcast` flag. Others will print the message once received.
+
+### Participant 0 (Bootstrapper and Broadcaster)
+
+```bash
+cargo run --release -- --me 0@3000 --participants 0,1,2,3 --broadcast "hello world"
+```
+
+### Participant 1
+
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 1@3001 --participants 0,1,2,3
+```
+
+### Participant 2
+
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 2@3002 --participants 0,1,2,3
+```
+
+### Participant 3
+
+```bash
+cargo run --release -- --bootstrappers 0@127.0.0.1:3000 --me 3@3003 --participants 0,1,2,3
+```

--- a/examples/broadcast-demo/src/main.rs
+++ b/examples/broadcast-demo/src/main.rs
@@ -1,0 +1,128 @@
+//! Demonstrate the `commonware-broadcast` primitive by sending a message from one participant to others.
+
+mod message;
+
+use clap::{value_parser, Arg, Command};
+use commonware_broadcast::buffered::{self, Engine};
+use commonware_codec::RangeCfg;
+use commonware_cryptography::{Ed25519, Signer};
+use commonware_p2p::authenticated::{self, Network};
+use commonware_runtime::{tokio, Metrics, Runner};
+use commonware_utils::{union, NZU32};
+use governor::Quota;
+use message::Message;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use tracing::info;
+
+const APPLICATION_NAMESPACE: &[u8] = b"broadcast-demo";
+
+fn main() {
+    let matches = Command::new("commonware-broadcast-demo")
+        .about("demonstrate commonware-broadcast")
+        .arg(Arg::new("me").long("me").required(true))
+        .arg(
+            Arg::new("participants")
+                .long("participants")
+                .required(true)
+                .value_delimiter(',')
+                .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            Arg::new("bootstrappers")
+                .long("bootstrappers")
+                .required(false)
+                .value_delimiter(',')
+                .value_parser(value_parser!(String)),
+        )
+        .arg(
+            Arg::new("broadcast")
+                .long("broadcast")
+                .required(false)
+                .help("Message to broadcast"),
+        )
+        .get_matches();
+
+    tracing_subscriber::fmt()
+        .json()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
+    let me = matches.get_one::<String>("me").expect("identity required");
+    let parts = me.split('@').collect::<Vec<_>>();
+    if parts.len() != 2 {
+        panic!("identity not well-formed");
+    }
+    let key = parts[0].parse::<u64>().expect("key not well-formed");
+    let port = parts[1].parse::<u16>().expect("port not well-formed");
+    let signer = Ed25519::from_seed(key);
+    info!(key = ?signer.public_key(), "loaded signer");
+
+    let participants = matches
+        .get_many::<u64>("participants")
+        .expect("provide participants")
+        .map(|p| Ed25519::from_seed(*p).public_key())
+        .collect::<Vec<_>>();
+
+    let mut bootstrappers = Vec::new();
+    if let Some(list) = matches.get_many::<String>("bootstrappers") {
+        for b in list {
+            let parts = b.split('@').collect::<Vec<_>>();
+            let k = parts[0].parse::<u64>().expect("bootstrapper key not well-formed");
+            let addr = SocketAddr::from_str(parts[1]).expect("bootstrapper addr not well-formed");
+            bootstrappers.push((Ed25519::from_seed(k).public_key(), addr));
+        }
+    }
+
+    let maybe_broadcast = matches.get_one::<String>("broadcast").cloned();
+
+    let executor = tokio::Runner::default();
+    executor.start(|context| async move {
+        let p2p_cfg = authenticated::Config::aggressive(
+            signer.clone(),
+            &union(APPLICATION_NAMESPACE, b"_P2P"),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port),
+            bootstrappers.clone(),
+            1024 * 1024,
+        );
+
+        let (mut network, mut oracle) = Network::new(context.with_label("network"), p2p_cfg);
+
+        oracle.register(0, participants.clone()).await;
+
+        let (sender, receiver) = network.register(
+            0,
+            Quota::per_second(NZU32!(10)),
+            256,
+            Some(3),
+        );
+
+        let cfg = buffered::Config {
+            public_key: signer.public_key(),
+            mailbox_size: 1024,
+            deque_size: 10,
+            priority: false,
+            codec_config: RangeCfg::from(0..=1024usize),
+        };
+        let (engine, mut mailbox) = Engine::new(context.with_label("broadcast"), cfg);
+
+        network.start();
+        engine.start((sender, receiver));
+
+        if let Some(msg) = maybe_broadcast.clone() {
+            let message = Message::new(0, msg.into_bytes());
+            mailbox.broadcast(commonware_p2p::Recipients::All, message)
+                .await
+                .await
+                .ok();
+            info!("broadcast sent");
+        }
+
+        let commitment = Message::commitment_for_id(0);
+        let received = mailbox.subscribe(None, commitment, None).await.await.unwrap();
+        println!("Received: {}", String::from_utf8_lossy(&received.data));
+
+        context.sleep(std::time::Duration::from_secs(1)).await;
+    });
+}

--- a/examples/broadcast-demo/src/message.rs
+++ b/examples/broadcast-demo/src/message.rs
@@ -1,0 +1,54 @@
+use bytes::{Buf, BufMut};
+use commonware_codec::{EncodeSize, Error as CodecError, RangeCfg, Read, ReadRangeExt, ReadExt, Write};
+use commonware_cryptography::{hash, sha256::Digest as Sha256Digest, Committable, Digestible};
+
+#[derive(Debug, Clone)]
+pub struct Message {
+    pub id: u32,
+    pub data: Vec<u8>,
+}
+
+impl Message {
+    pub fn new(id: u32, data: impl Into<Vec<u8>>) -> Self {
+        Self { id, data: data.into() }
+    }
+
+    pub fn commitment_for_id(id: u32) -> Sha256Digest {
+        hash(&id.to_le_bytes())
+    }
+}
+
+impl Digestible<Sha256Digest> for Message {
+    fn digest(&self) -> Sha256Digest {
+        hash(&self.data)
+    }
+}
+
+impl Committable<Sha256Digest> for Message {
+    fn commitment(&self) -> Sha256Digest {
+        Self::commitment_for_id(self.id)
+    }
+}
+
+impl Write for Message {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.id.write(buf);
+        self.data.write(buf);
+    }
+}
+
+impl EncodeSize for Message {
+    fn encode_size(&self) -> usize {
+        self.id.encode_size() + self.data.encode_size()
+    }
+}
+
+impl Read for Message {
+    type Cfg = RangeCfg;
+
+    fn read_cfg(buf: &mut impl Buf, range: &Self::Cfg) -> Result<Self, CodecError> {
+        let id = u32::read(buf)?;
+        let data = Vec::<u8>::read_range(buf, *range)?;
+        Ok(Self { id, data })
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `commonware-broadcast-demo` example crate
- demonstrate broadcasting a message between four nodes
- update workspace members

## Testing
- `cargo check -p commonware-broadcast-demo` *(fails: failed to download crates)*